### PR TITLE
Added rancheros-installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,44 @@ If you are running from the ISO RancherOS will be running from memory.  In order
 
     docker run --privileged -it debian mkfs.ext4 -L RANCHER_STATE /dev/sda
 
-## Installing to Disk/Upgrading
+## Installing to Disk
 
-Coming soon (but you can guess it's all based on Docker)
+To install RancherOS on a new disk you can now use the `rancheros-install` command. 
 
+For non-ec2 installs, before getting started create a cloud-init file that will provide your initial ssh keys. At a minimum something like:
+
+```
+ #cloud-config
+ ssh_authorized_keys:
+  - ssh-rsa AAA... user@rancher
+```
+
+See section below for current supported cloud-init functionality.
+
+The command arguments are as follows:
+
+```
+Usage:
+  rancheros-install [options]
+Options:
+  -c cloud-config file
+      needed for SSH keys.
+  -d device
+  -f [ DANGEROUS! Data loss can happen ] partition/format without prompting
+  -t install-type:
+       generic
+       amazon-ebs
+  -v os-installer version.
+  -h print this
+ ```
+ 
+ This command orchestrates installation from the rancher/os-installer container. 
+ 
+####Examples:
+ Virtualbox installation:
+ 
+ `sudo rancheros-install -d /dev/sda -c ./cloud_data.yml -v v0.1.1 -t generic`
+ 
 ## Configuring
 
 The entire state of RancherOS is controlled by a single configuration document.

--- a/scripts/dockerimages/06-console
+++ b/scripts/dockerimages/06-console
@@ -1,6 +1,7 @@
 FROM base
 COPY scripts/dockerimages/scripts/console.sh /usr/sbin/
 COPY scripts/dockerimages/scripts/update-ssh-keys /usr/bin/
+COPY scripts/dockerimages/scripts/rancheros-install /usr/sbin/
 RUN sed -i 's/rancher:!/rancher:*/g' /etc/shadow && \
     echo '## allow password less for rancher user' >> /etc/sudoers && \
     echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers

--- a/scripts/dockerimages/scripts/rancheros-install
+++ b/scripts/dockerimages/scripts/rancheros-install
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -e
+
+usage()
+{
+cat <<EOF
+Usage: 
+  rancheros-install [options]
+Options:
+  -c cloud-config file
+      needed for SSH keys.
+  -d device
+  -f [ DANGEROUS! Data loss can happen ] partition/format without prompting
+  -t install-type:
+        generic:    Creates 1 ext4 partition and installs RancherOS
+        amazon-ebs: Installs RancherOS and sets up PV-GRUB
+  -v os-installer version.
+  -h print this
+EOF
+}
+
+PARTITION_FLAG="false"
+INSTALLER_VERSION="latest"
+EXTRA_ARGS=
+
+while getopts "c:d:ft:v:h" OPTION
+do
+    case $OPTION in
+        c) CLOUD_CONFIG="$OPTARG" ;;
+        d) DEVICE="$OPTARG" ;;
+        f) FORCE_INSTALL="true" ;;
+        # p) PARTITION_FLAG="true" ;;
+        t) INSTALL_TYPE="${OPTARG}" ;;
+        v) INSTALLER_VERSION="$OPTARG" ;;
+        h) usage; exit ;;
+        *) exit 1 ;;
+    esac
+done
+
+if [ "$(whoami)" != "root" ]; then
+    echo "Please run as root." 1>&2
+    exit 1
+fi
+
+if [[ -z "${INSTALL_TYPE}" ]]; then
+    echo "$0: No install type specified, -t required to install" 1>&2
+    exit 1
+fi
+
+if [ -z "${CLOUD_CONFIG}" ] && [ "${INSTALL_TYPE}" != "amazon-ebs" ]; then
+    echo "$0: called without cloud config. Can not proceed without -c" 1>&2
+    exit 1
+fi
+
+if [ "${INSTALL_TYPE}" == "generic" ]; then
+    PARTITION_FLAG="true"
+fi
+
+if [[ ! -z "${CLOUD_CONFIG}" ]]; then
+    cp ${CLOUD_CONFIG} /opt/user_config.yml
+    EXTRA_ARGS='-c /opt/user_config.yml'
+fi
+
+if [ "${FORCE_INSTALL}" != "true" ] && [ "${INSTALL_TYPE}" != "rancher-upgrade" ]; then
+    echo "All data will be wiped from this device"
+    printf "Partition: ${PARTITION_FLAG}\nDEVICE: ${DEVICE}\n"
+    read -p "Are you sure you want to continue? [yN]" -n 1 -r confirmation
+    if [ "$confirmation" != "y" ]; then
+        echo "Exiting..."
+        exit 1
+    fi
+fi
+
+if [ "$PARTITION_FLAG" == "true" ]; then
+    system-docker run --net=host -it --privileged --entrypoint=/scripts/set-disk-partitions rancher/os-installer:${INSTALLER_VERSION} ${DEVICE}
+    system-docker start udev
+fi
+
+system-docker run --volumes-from=user-volumes --net=host -it --privileged rancher/os-installer:${INSTALLER_VERSION} -d ${DEVICE} -t ${INSTALL_TYPE} ${EXTRA_ARGS}
+
+echo "RancherOS has been installed. Please reboot..."


### PR DESCRIPTION
This script will call out to pull an os-installer container. It handles
orchestrating the install process.

The [os-installer repository](https://github.com/cloudnautique/os-installer) can be reviewed at the same time. There is an image on Docker hub already for the v0.1.1 release.