### PR TITLE
Fix home directory not owned by rancher

### DIFF
--- a/scripts/dockerimages/scripts/console.sh
+++ b/scripts/dockerimages/scripts/console.sh
@@ -55,8 +55,11 @@ EOF
 RANCHER_HOME=/home/rancher
 if [ ! -d ${RANCHER_HOME} ]; then
     mkdir -p ${RANCHER_HOME}
-    chown rancher:rancher ${RANCHER_HOME}
     chmod 2755 ${RANCHER_HOME}
+fi
+
+if [ "$(ls -ld ${RANCHER_HOME}|grep rancher|awk -e '{print $3}')" != "rancher" ]; then
+    chown rancher:rancher ${RANCHER_HOME}
 fi
 
 if ! grep -q "$(hostname)" /etc/hosts; then


### PR DESCRIPTION
When installed on disk, the home directory ends up owned root:root.
This change checks and assigns the rancher:rancher owner.