### PR TITLE
Add OEM support to network dhcp container.

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -35,6 +35,7 @@ type Config struct {
 	CloudInit           CloudInit         `yaml:"cloud_init,omitempty"`
 	Console             ConsoleConfig     `yaml:"console,omitempty"`
 	Debug               bool              `yaml:"debug,omitempty"`
+	Oem                 string            `yaml:"oem,omitempty"`
 	Disable             []string          `yaml:"disable,omitempty"`
 	EnabledAddons       []string          `yaml:"enabled_addons,omitempty"`
 	Modules             []string          `yaml:"modules,omitempty"`

--- a/scripts/dockerimages/03-network
+++ b/scripts/dockerimages/03-network
@@ -1,2 +1,3 @@
 FROM base
+COPY scripts/dockerimages/scripts/network/ /scripts
 CMD ["netconf"]

--- a/scripts/dockerimages/scripts/network/udhcpd-gce-config.sh
+++ b/scripts/dockerimages/scripts/network/udhcpd-gce-config.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# udhcpc script edited by Tim Riker <Tim@Rikers.org>
+
+[ -z "$1" ] && echo "Error: should be called from udhcpc" && exit 1
+
+RESOLV_CONF="/etc/resolv.conf"
+[ -e $RESOLV_CONF ] || touch $RESOLV_CONF
+[ -n "$broadcast" ] && BROADCAST="broadcast $broadcast"
+[ -n "$subnet" ] && NETMASK="netmask $subnet"
+
+
+case "$1" in
+        deconfig)
+                /sbin/ifconfig $interface up
+                /sbin/ifconfig $interface 0.0.0.0
+
+                # drop info from this interface
+                # resolv.conf may be a symlink to /tmp/, so take care
+                TMPFILE=$(mktemp)
+                grep -vE "# $interface\$" $RESOLV_CONF > $TMPFILE
+                cat $TMPFILE > $RESOLV_CONF
+                rm -f $TMPFILE
+
+                if [ -x /usr/sbin/avahi-autoipd ]; then
+                        /usr/sbin/avahi-autoipd -k $interface
+                fi
+                ;;
+
+        leasefail|nak)
+                if [ -x /usr/sbin/avahi-autoipd ]; then
+                        /usr/sbin/avahi-autoipd -wD $interface --no-chroot
+                fi
+                ;;
+
+        renew|bound)
+                if [ -x /usr/sbin/avahi-autoipd ]; then
+                        /usr/sbin/avahi-autoipd -k $interface
+                fi
+                /sbin/ifconfig $interface $ip $BROADCAST $NETMASK
+                /sbin/ifconfig $interface mtu $mtu
+
+                if [ -n "$router" ] ; then
+                        echo "deleting routers"
+                        while route del default gw 0.0.0.0 dev $interface 2> /dev/null; do
+                                :
+                        done
+
+                        for i in $router ; do
+                                ip route add $i/32 dev $interface
+                                ip route add default via $i
+                        done
+                fi
+
+                # drop info from this interface
+                # resolv.conf may be a symlink to /tmp/, so take care
+                TMPFILE=$(mktemp)
+                grep -vE "# $interface\$" $RESOLV_CONF > $TMPFILE
+                cat $TMPFILE > $RESOLV_CONF
+                rm -f $TMPFILE
+
+                [ -n "$domain" ] && echo "search $domain # $interface" >> $RESOLV_CONF
+                for i in $dns ; do
+                        echo adding dns $i
+                        echo "nameserver $i # $interface" >> $RESOLV_CONF
+                done
+                ;;
+esac
+
+HOOK_DIR="$0.d"
+for hook in "${HOOK_DIR}/"*; do
+    [ -f "${hook}" -a -x "${hook}" ] || continue
+    "${hook}" "${@}"
+done
+
+exit 0


### PR DESCRIPTION
In order to get the networking configuration to work on GCE, we
needed to add a custom network interface configuration. This change
makes it possible to do so, and if we need other providers.

This is likely deprecated by PR #122