### PR TITLE
cloud-config write_files should write to absolute path

### DIFF
--- a/cmd/cloudinit/cloudinit.go
+++ b/cmd/cloudinit/cloudinit.go
@@ -195,7 +195,7 @@ func Main() {
 
 	for _, file := range cc.WriteFiles {
 		f := system.File{File: file}
-		fullPath, err := system.WriteFile(&f, outputDir)
+		fullPath, err := system.WriteFile(&f, "/")
 		if err != nil {
 			log.Fatalf("%v", err)
 		}


### PR DESCRIPTION
bug?
`write_files: [{path: /var/lib/rancher/conf/nginx.yml}]` writes to
`/var/lib/rancher/conf/var/lib/rancher/conf/nginx.yml`