### PR TITLE
do boot2docker style initilization

### DIFF
--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -3,6 +3,7 @@ package init
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
@@ -11,6 +12,8 @@ import (
 	"github.com/rancherio/os/util"
 	"github.com/rancherio/rancher-compose/project"
 )
+
+const boot2dockerMagic = "boot2docker, please format-me"
 
 func autoformat(cfg *config.Config) error {
 	if len(cfg.State.Autoformat) == 0 || util.ResolveDevice(cfg.State.Dev) != "" {
@@ -43,10 +46,18 @@ outer:
 			continue
 		}
 
-		for _, b := range buffer {
-			if b != 0 {
-				log.Infof("%s not empty", dev)
-				continue outer
+		boot2docker := false
+
+		if strings.HasPrefix(string(buffer), boot2dockerMagic) {
+			boot2docker = true
+		}
+
+		if boot2docker == false {
+			for _, b := range buffer {
+				if b != 0 {
+					log.Infof("%s not empty", dev)
+					continue outer
+				}
 			}
 		}
 
@@ -73,6 +84,9 @@ outer:
 					config.SCOPE + "=" + config.SYSTEM,
 				},
 				LogDriver: "json-file",
+				Environment: []string{
+					"MAGIC=" + boot2dockerMagic,
+				},
 			},
 			"udev": &udev,
 		})

--- a/scripts/dockerimages/scripts/auto-format.sh
+++ b/scripts/dockerimages/scripts/auto-format.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+set -ex
+
 if [ -n "$1" ]; then
-    exec mkfs.ext4 -L RANCHER_STATE $1
+    # Test for our magic string (it means that the disk was made by ./boot2docker init)
+    HEADER=`dd if=$1 bs=1 count=${#MAGIC} 2>/dev/null`
+
+    if [ "$HEADER" = "$MAGIC" ]; then
+        # save the preload userdata.tar file
+	dd if=$1 of=/userdata.tar bs=1 count=8192
+    fi
+
+    mkfs.ext4 -L RANCHER_STATE $1
+
+    if [ -e "/userdata.tar" ]; then
+        mount -t ext4 $1 /var/
+        mkdir -p /var/lib/rancher/conf/cloud-config.d
+        echo $(tar -xvf /userdata.tar)
+        AUTHORIZED_KEYS1=$(cat /.ssh/authorized_keys)
+        echo -e "#cloud-config\n\nssh_authorized_keys:\n - $AUTHORIZED_KEYS1" > /var/lib/rancher/conf/cloud-config.d/machine.yml
+        AUTHORIZED_KEYS2=$(cat /.ssh/authorized_keys2)
+        echo -e " - $AUTHORIZED_KEYS2" >> /var/lib/rancher/conf/cloud-config.d/machine.yml
+    fi
 fi
+


### PR DESCRIPTION
@ibuildthecloud - This can do boot2docker style initialization and save the cloud config file in `/var/lib/rancher.conf`

I'll add a mechanism to use the generated cloud config yaml file as another PR.