### PR TITLE
Update os.go

### DIFF
--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -165,9 +165,10 @@ func startUpgradeContainer(image string, stage, force bool) {
 		log.Fatal(container.Err)
 	}
 
-	fmt.Printf("Upgrading to %s\n", image)
-
+	
 	if !stage {
+		fmt.Printf("Upgrading to %s\n", image)
+
 		if !force {
 			if !yes(in, "Continue") {
 				os.Exit(1)


### PR DESCRIPTION
Moved the printout of "Upgrading to rancher/os:v.xxx" so that it only prints out if it's not staging.

Fixes https://github.com/rancherio/os/issues/152