### PR TITLE
Disable predictable naming.

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -30,7 +30,7 @@ default rancheros
 label rancheros
     kernel /boot/vmlinuz
     initrd /boot/initrd
-    append quiet rancher.password=rancher
+    append quiet rancher.password=rancher net.ifnames=0
 EOF
 
 cd ${CD}
@@ -49,7 +49,7 @@ default rancheros
 label rancheros
     kernel /boot/vmlinuz
     initrd /boot/initrd
-    append quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]
+    append quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda] net.ifnames=0
 EOF
 
 cd ${CD}


### PR DESCRIPTION
When we upgraded udev, we also started using predictable naming for
interfaces. This has caused connectivity issues in a variety of
environments. Disabling for now.

For background:
http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/

Issues stemming from this:
#171 
#173 (will address in OS installer) 
