### PR TITLE
Revert "Use consistent device names"

### DIFF
--- a/scripts/dockerimages/00-base
+++ b/scripts/dockerimages/00-base
@@ -1,5 +1,6 @@
 FROM scratch
 ADD assets/rootfs.tar /
+RUN ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 # Cleanup Buildroot
 RUN rm /sbin/poweroff /sbin/reboot /sbin/halt && \
     sed -i '/^root/s!/bin/sh!/bin/bash!' /etc/passwd && \


### PR DESCRIPTION
This reverts commit 402cbbdf6f3e6b4eb547d2d1cac3eac5bee38501.

This negates the need for #174 