### PR TITLE
add acpid to console

### DIFF
--- a/scripts/dockerimages/scripts/console.sh
+++ b/scripts/dockerimages/scripts/console.sh
@@ -93,6 +93,9 @@ BUG_REPORT_URL=
 BUILD_ID=
 EOF
 
+# start acpi daemon
+/usr/sbin/acpid 
+
 if ! grep -q "$(hostname)" /etc/hosts; then
     echo 127.0.1.1 $(hostname) >> /etc/hosts
 fi


### PR DESCRIPTION
@ibuildthecloud -- this is the easiest way to add it, the other option is to create a separate docker container for it, not sure if we need another container for running the acpi daemon.