### PR TITLE
ubuntu-console: add vim

### DIFF
--- a/scripts/extraimages/00-ubuntuconsole
+++ b/scripts/extraimages/00-ubuntuconsole
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04.2
 RUN apt-get update && \
     apt-get upgrade --no-install-recommends -y && \
-    apt-get install -y --no-install-recommends openssh-server rsync
+    apt-get install -y --no-install-recommends openssh-server rsync vim
 RUN rm -rf /etc/ssh/*key*
 COPY scripts/dockerimages/scripts/entry.sh /usr/sbin/
 COPY scripts/dockerimages/scripts/console.sh /usr/sbin/


### PR DESCRIPTION
ubuntu-console: add vim

Surprisingly, `vi` in ubuntu-console is very poor 
compared to the one in default console.