### PR TITLE
rancherctl env subcommand

### DIFF
--- a/cmd/control/cli.go
+++ b/cmd/control/cli.go
@@ -25,6 +25,14 @@ func Main() {
 			Subcommands: configSubcommands(),
 		},
 		{
+			Name:               "env",
+			ShortName:          "e",
+			Usage:              "env command",
+			HideHelp:           true,
+			SkipFlagParsing:    true,
+			Action:             envAction,
+		},
+		{
 			Name:        "service",
 			ShortName:   "s",
 			Usage:       "service settings",

--- a/cmd/control/env.go
+++ b/cmd/control/env.go
@@ -1,0 +1,39 @@
+package control
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/codegangsta/cli"
+	"github.com/rancherio/os/config"
+	"github.com/rancherio/os/util"
+)
+
+func envAction(c *cli.Context) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	args := c.Args()
+	osEnv := os.Environ()
+
+	envMap := make(map[string]string, len(cfg.Environment) + len(osEnv))
+	for k, v := range cfg.Environment {
+		envMap[k] = v
+	}
+	for k, v := range util.KVPairs2Map(osEnv) {
+		envMap[k] = v
+	}
+
+	if cmd, err := exec.LookPath(args[0]); err != nil {
+		log.Fatal(err)
+	} else {
+		args[0] = cmd
+	}
+	if err := syscall.Exec(args[0], args, util.Map2KVPairs(envMap)); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -314,9 +314,8 @@ func Map2KVPairs(m map[string]string) []string {
 func KVPairs2Map(kvs []string) map[string]string {
 	r := make(map[string]string, len(kvs))
 	for _, kv := range kvs {
-		sepIdx := strings.Index(kv, "=")
-		k, v := kv[:sepIdx], kv[(sepIdx + 1):]
-		r[k] = v
+		s := strings.SplitN(kv, "=", 2)
+		r[s[0]] = s[1]
 	}
 	return r
 }

--- a/util/util.go
+++ b/util/util.go
@@ -302,3 +302,21 @@ func GetValue(kvPairs []string, key string) string {
 
 	return ""
 }
+
+func Map2KVPairs(m map[string]string) []string {
+	r := make([]string, 0, len(m))
+	for k, v := range m {
+		r = append(r, k + "=" + v)
+	}
+	return r
+}
+
+func KVPairs2Map(kvs []string) map[string]string {
+	r := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		sepIdx := strings.Index(kv, "=")
+		k, v := kv[:sepIdx], kv[(sepIdx + 1):]
+		r[k] = v
+	}
+	return r
+}


### PR DESCRIPTION
`rancherctl env` subcommand

Usage:
`rancherctl env <command>`

Executes `<command>` with environment from rancher.environment. Real env vars override those from rancher.environment.