### PR TITLE
Fix #139: show IP address in login screen

### DIFF
--- a/scripts/dockerimages/scripts/console.sh
+++ b/scripts/dockerimages/scripts/console.sh
@@ -104,6 +104,8 @@ if ! grep -q "$(hostname)" /etc/hosts; then
     echo 127.0.1.1 $(hostname) >> /etc/hosts
 fi
 
+echo $(/sbin/ifconfig | grep -B1 "inet addr" |awk '{ if ( $1 == "inet" ) { print $2 } else if ( $2 == "Link" ) { printf "%s:" ,$1 } }' |awk -F: '{ print $1 ": " $3}') >> /etc/issue
+
 if [ -x /opt/rancher/bin/start.sh ]; then
     echo Executing custom script
     /opt/rancher/bin/start.sh || true


### PR DESCRIPTION
Following coreos convention, we print all the addresses set on all of the network interfaces

Signed-off-by: wlan0 <sidharthamn@gmail.com>

This is what the screen looks like now 

```
INFO[0003] [9/15] [network]: Started                    
INFO[0004] [10/15] [userdocker]: Started                
[    9.408110] Bridge firewalling registered
[    9.477852] hrtimer: interrupt took 9756874 ns
[    9.558532] IPv6: ADDRCONF(NETDEV_UP): docker0: link is not ready
INFO[0004] [11/15] [cloud-init]: Started                
INFO[0004] [12/15] [userdockerwait]: Started            
INFO[0004] [13/15] [console]: Started                   
INFO[0005] [14/15] [ntp]: Started                       
INFO[0005] [15/15] [acpid]: Started                     
INFO[0005] RancherOS v0.3.0 started                     
INFO[0005] Addresses on lo are [127.0.0.1/8 ::1/128]    
INFO[0005] Addresses on docker-sys are [172.18.42.1/16 fe80::a469:4cff:fe81:4df0/64] 
INFO[0005] Addresses on eth0 are [10.0.2.15/24 fe80::5054:ff:fe12:3456/64] 
INFO[0005] Addresses on docker0 are [172.17.42.1/16]    
```

@sheng-liang 