### PR TITLE
Fix #253: Do not fail boot if module cannot be loaded

### DIFF
--- a/init/init.go
+++ b/init/init.go
@@ -198,7 +198,7 @@ func loadModules(cfg *config.Config) error {
 		log.Debugf("Loading module %s", module)
 		err = exec.Command("/sbin/modprobe", module).Run()
 		if err != nil {
-			return err
+			log.Errorf("Could not load module %s, err %v", module, err)
 		}
 	}
 


### PR DESCRIPTION
@ibuildthecloud 

This is the error message 

```
INFO[0003] [1/1] [udev]: Started                        
INFO[0004] Mounting state device /dev/vda to /var       
[    5.168606] EXT4-fs (vda): recovery complete
[    5.171386] EXT4-fs (vda): mounted filesystem with ordered data mode. Opts: (null)
ERRO[0004] Could not load module xyzabc123, err exit status 1 
INFO[0004] Launching System Docker                      
INFO[0000] Waiting for Docker at unix:///var/run/system-docker.sock 
[    5.277473] nf_conntrack version 0.5.0 (7995 buckets, 31980 max)
[    5.292909] ip_tables: (C) 2000-2006 Netfilter Core Team
```
