### PR TITLE
Bugfix: cloud_init datasource "cmdline" should not expect a value

### DIFF
--- a/cmd/cloudinit/cloudinit.go
+++ b/cmd/cloudinit/cloudinit.go
@@ -397,7 +397,7 @@ func getDatasources(cfg *rancherConfig.Config) []datasource.Datasource {
 				dss = append(dss, url.NewDatasource(parts[1]))
 			}
 		case "cmdline":
-			if len(parts) == 2 {
+			if len(parts) == 1 {
 				dss = append(dss, proc_cmdline.NewDatasource())
 			}
 		case "configdrive":


### PR DESCRIPTION
Problem: Datasource of type `cmdline` is not processed unless a value is given. Alas, cloud-init's `proc_cmdline` method does not take any arguments at all.