### PR TITLE
BUGFIX: Boot stalls for 5 mins in cloud-init-pre

### DIFF
--- a/cmd/cloudinit/cloudinit.go
+++ b/cmd/cloudinit/cloudinit.go
@@ -393,12 +393,16 @@ func getDatasources(cfg *rancherConfig.Config) []datasource.Datasource {
 				dss = append(dss, file.NewDatasource(parts[1]))
 			}
 		case "url":
-			if len(parts) == 2 {
-				dss = append(dss, url.NewDatasource(parts[1]))
+			if network {
+				if len(parts) == 2 {
+					dss = append(dss, url.NewDatasource(parts[1]))
+				}
 			}
 		case "cmdline":
-			if len(parts) == 1 {
-				dss = append(dss, proc_cmdline.NewDatasource())
+			if network {
+				if len(parts) == 1 {
+					dss = append(dss, proc_cmdline.NewDatasource())
+				}
 			}
 		case "configdrive":
 			if len(parts) == 2 {


### PR DESCRIPTION
Found this while experimenting with IPXE booting.

Problem: When `cloud-init datasource` is set to `url` or `cmdline` the init procedure hangs for 5 mins because the cloud-init-pre service tries to fetch the remote URL's although the network is not available at this init stage.

Proof:
```
May 14 04:36:40 rancher docker/792f565e8ce6[1]: + rancherctl config get cloud_init
May 14 04:36:40 rancher acpid: starting up with netlink and the input layer
May 14 04:36:40 rancher acpid: 1 rule loaded
May 14 04:36:40 rancher acpid: waiting for events: event logging is off
May 14 04:36:40 rancher docker/792f565e8ce6[1]: datasources:
May 14 04:36:40 rancher docker/792f565e8ce6[1]: - url:https://gist.githubusercontent.com/janeczku/d334f4029d6a7d749cfd/raw/e966df8a1806b5faee4ce63d347b2f9bd4e788f6/userdata-live.yaml
May 14 04:36:40 rancher docker/792f565e8ce6[1]: 
May 14 04:36:40 rancher docker/792f565e8ce6[1]: + cloud-init -save -network=false
May 14 04:36:40 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:40Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:36:40 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:40Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:36:40 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:40Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:36:41 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:41Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:36:42 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:42Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:36:43 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:43Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:36:46 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:46Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:36:53 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:36:53Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:37:06 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:37:06Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:37:31 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:37:31Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:38:01 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:38:01Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:38:31 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:38:31Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:39:01 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:39:01Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:39:31 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:39:31Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:40:01 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:40:01Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:40:31 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:40:31Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:41:01 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:41:01Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:41:31 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:41:31Z" level=info msg="Checking availability of \"url\"\n" 
May 14 04:41:40 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:41:40Z" level=error msg="Unrecognized cloud-init\n" 
May 14 04:41:40 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:41:40Z" level=info msg="/var/lib/rancher/conf/cloud-config.d does not exist, not merging" 
May 14 04:41:40 rancher docker/792f565e8ce6[1]: time="2015-05-14T04:41:40Z" level=info msg="Writing to /var/lib/rancher/conf/cloud-config-processed.yml" 
May 14 04:41:40 rancher dhcpcd[12]: version 6.6.7 starting
May 14 04:41:40 rancher docker/196ce207eb1a[1]: time="2015-05-14T04:41:40Z" level=info msg="Set 127.0.0.1/8 on lo" 
May 14 04:41:40 rancher docker/196ce207eb1a[1]: dhcpcd[12]: version 6.6.7 starting
May 14 04:41:40 rancher docker/196ce207eb1a[1]: time="2015-05-14T04:41:40Z" level=info msg="Running DHCP on eth0" 
```