### PR TITLE
prevent `nil` from being put back to `c.Container`

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -532,7 +532,6 @@ func (c *Container) start(createOnly, wait bool) *Container {
 		return c.returnErr(err)
 	}
 
-	container := c.Container
 	created := false
 
 	opts, err := c.getCreateOpts(client)
@@ -566,14 +565,12 @@ func (c *Container) start(createOnly, wait bool) *Container {
 			return c.returnErr(err)
 		}
 
-		container, err = client.CreateContainer(*opts)
+		c.Container, err = client.CreateContainer(*opts)
 		created = true
 		if err != nil {
 			return c.returnErr(err)
 		}
 	}
-
-	c.Container = container
 
 	hostConfig := c.Container.HostConfig
 	if created {


### PR DESCRIPTION
prevent `nil` from being put back to `c.Container`

`c.Exists()` is an innocent looking function being in fact a mutating operation: 
`c.Container` may be `nil` before and hold a looked up value after the call.

hopefully, fixes #309