### PR TITLE
Enhance sshd security: disallow root login

### DIFF
--- a/scripts/dockerimages/scripts/console.sh
+++ b/scripts/dockerimages/scripts/console.sh
@@ -79,7 +79,8 @@ cat > /etc/respawn.conf << EOF
 EOF
 
 if ! grep -q '^UseDNS no' /etc/ssh/sshd_config; then
-    echo "UseDNS no" >> /etc/ssh/sshd_config
+    echo "UseDNS no
+PermitRootLogin no" >> /etc/ssh/sshd_config
 fi
 
 ID_TYPE="busybox"


### PR DESCRIPTION
Today I saw a lot of "strange" lines in my logs:
```
May 26 21:45:43 rancher sshd[1199]: Received disconnect from 222.186.21.134: 11:  [preauth]
May 26 21:45:50 rancher sshd[1209]: Failed password for root from 222.186.21.134 port 41293 ssh2
May 26 21:45:52 rancher sshd[1209]: Failed password for root from 222.186.21.134 port 41293 ssh2
May 26 21:45:55 rancher sshd[1209]: Failed password for root from 222.186.21.134 port 41293 ssh2
```
Given that no password or ssh key is ever set for root it's better to disallow root ssh login

Note: Maybe password login could be disallow too: `PasswordAuthentication no`

