### PR TITLE
empty ServicesInclude map in default config

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -380,9 +380,7 @@ func NewConfig() *Config {
 				Net: "host",
 			},
 		},
-		ServicesInclude: map[string]bool{
-			"ubuntu-console": false,
-		},
+		ServicesInclude: map[string]bool{},
 		Repositories: map[string]Repository{
 			"core": Repository{
 				Url: "https://raw.githubusercontent.com/rancherio/os-services/" + DEFAULT_IMAGE_VERSION,


### PR DESCRIPTION
empty ServicesInclude map in default config

it's not needed anymore as we are using os-services repo