### PR TITLE
build scripts: update to rancher/dind:v0.5.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,6 @@ cd $(dirname $0)
 
 export DOCKER_IMAGE=rancher-os-build
 
-source ./scripts/version
-
 ./scripts/ci
 
 rm -rf dist

--- a/scripts/build
+++ b/scripts/build
@@ -20,7 +20,7 @@ done
 
 if [ "$IN_DOCKER" != "true" ]; then
     cat > .dockerfile << "EOF"
-FROM rancher/dind:v0.1.0
+FROM rancher/dind:v0.5.0
 COPY ./scripts/bootstrap /scripts/bootstrap
 RUN /scripts/bootstrap
 WORKDIR /source

--- a/scripts/build-common
+++ b/scripts/build-common
@@ -9,6 +9,8 @@ DOCKER_FILE=${CONFIG}/.dockerfile
 
 write_base()
 {
+    DOCKER_BASE=${DOCKER_BASE:?"DOCKER_BASE not defined"}
+
     if [ "${BASE_WRITTEN}" = "true" ]; then
         return
     fi
@@ -16,7 +18,7 @@ write_base()
     mkdir -p $(dirname ${DOCKER_FILE})
 
     cat > ${DOCKER_FILE} << EOF
-FROM ${DOCKER_BASE:=ubuntu:14.04.2}
+FROM ${DOCKER_BASE}
 ENV TERM xterm
 ENV IN_DOCKER true
 WORKDIR /source

--- a/scripts/ci
+++ b/scripts/ci
@@ -4,7 +4,7 @@ set -ex
 cd $(dirname $0)/..
 
 export DOCKER_IMAGE=${DOCKER_IMAGE:=rancher-os-build}
-export DOCKER_BASE=rancher/dind:v0.1.0
+export DOCKER_BASE=rancher/dind:v0.5.0
 
 source scripts/build-common
 mkdir -p ${BUILD}


### PR DESCRIPTION
build scripts: update to rancher/dind:v0.5.0

because docker-1.7 is now required to successfully pull images from DockerHub